### PR TITLE
show requirements for implicitDeps

### DIFF
--- a/.moon/tasks/typescript-library.yml
+++ b/.moon/tasks/typescript-library.yml
@@ -13,4 +13,5 @@ tasks:
     outputs:
       - 'dist'
     deps:
+      - '^:codegen'
       - '^:build'

--- a/.moon/tasks/typescript.yml
+++ b/.moon/tasks/typescript.yml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://moonrepo.dev/schemas/tasks.json
 
 implicitDeps:
-  - '^:codegen'
   - '^:build'
 
 implicitInputs:


### PR DESCRIPTION
```
moon action-graph example-app:run --dependents
```

<img width="814" alt="image" src="https://github.com/user-attachments/assets/8e5d3ee5-0cf0-4896-8a23-342f2430930e">

versus with `implicitDeps` defined

<img width="836" alt="image" src="https://github.com/user-attachments/assets/49c0538c-6f9c-4b67-adba-d65fa1f7d645">
